### PR TITLE
Type cleanup

### DIFF
--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -19,15 +19,15 @@ export default function DeploymentFilter({
   initialProjects = [],
   projectOptions,
 }: {
-  apiPath?: string,
-  initialBounds?: RectBounds,
+  apiPath?: string | null,
+  initialBounds?: RectBounds | null,
   initialSpecies?: string[],
   initialProjects?: number[],
   projectOptions: { value: number, label: string }[],
 }) {
   const router = useRouter();
 
-  const [rectBounds, setRectBounds] = useState<RectBounds>(initialBounds);
+  const [rectBounds, setRectBounds] = useState<RectBounds | null>(initialBounds);
   const [filterSpecies, setFilterSpecies] = useState<string[]>(initialSpecies);
   const [filterProjects, setFilterProjects] = useState<number[]>(initialProjects);
   const [speciesUrl, setSpeciesUrl] = useState<string>(`/api/species?${new URLSearchParams({

--- a/next/modules/map/components/DeploymentMultiselect.tsx
+++ b/next/modules/map/components/DeploymentMultiselect.tsx
@@ -22,7 +22,7 @@ export default function DeploymentMultiselect(
     defaultValues?: { value: any, label: string }[],
   },
 ): React.ReactNode {
-  const [selectOptions, setSelectOptions] = useState(null);
+  const [selectOptions, setSelectOptions] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/next/modules/map/components/DeploymentPopup.tsx
+++ b/next/modules/map/components/DeploymentPopup.tsx
@@ -10,7 +10,11 @@ import {
 import Deployment from '@/common/types/deployment';
 
 export default function DeploymentPopup({ marker }: { marker: Deployment }) {
-  const [speciesData, setSpeciesData] = useState(null);
+  const [speciesData, setSpeciesData] = useState<{
+    species: string,
+    count: number,
+    nid: number,
+  }[] | null>(null);
 
   const onClick = () => {
     const fetcher = async () => {
@@ -23,7 +27,7 @@ export default function DeploymentPopup({ marker }: { marker: Deployment }) {
   };
 
   const formatSpecies = (data: { species: string, count: number, nid: number }[]): string => {
-    const species = [];
+    const species: string[] = [];
     data.map((speciesObject) => (
       species.push(speciesObject.species)
     ));

--- a/next/modules/map/types/GeoFilterMapProps.ts
+++ b/next/modules/map/types/GeoFilterMapProps.ts
@@ -1,10 +1,10 @@
 import RectBounds from '@/modules/map/types/RectBounds';
 
 export default interface GeoFilterMapProps {
-  filterBounds: RectBounds,
-  setFilter: React.Dispatch<React.SetStateAction<RectBounds>>,
-  apiPath: string,
+  filterBounds: RectBounds | null,
+  setFilter: React.Dispatch<React.SetStateAction<RectBounds | null>>,
+  apiPath: string | null,
   mapping: (mkr: any) => React.ReactNode,
-  initialBounds?: RectBounds,
+  initialBounds?: RectBounds | null,
   setCsvData: React.Dispatch<React.SetStateAction<any[]>>,
 }

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -30,7 +30,8 @@
       "@/common/*": [
         "common/*"
       ]
-    }
+    },
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Define types and change types that comply with strict null checks. This prevents any type error when building, and also helps to self-document the code by showing what data may result from some requests.