### PR TITLE
Common name

### DIFF
--- a/next/app/deployments/page.tsx
+++ b/next/app/deployments/page.tsx
@@ -14,6 +14,10 @@ export default async function Page({ searchParams }: { searchParams }) {
     method: 'GET',
   }).then((res) => res.json());
 
+  const speciesOptions = await fetch(`${process.env.API_DOMAIN}/species`, {
+    method: 'GET',
+  }).then((res) => res.json());
+
   const filtersApplied = (filterParams: {
     maxLat: number | null,
     minLat: number | null,
@@ -54,8 +58,21 @@ export default async function Page({ searchParams }: { searchParams }) {
         value: projectObj.nid,
         label: projectObj.name,
       }))}
+      speciesOptions={speciesOptions.map((speciesObj) => ({
+        value: speciesObj.species,
+        label: speciesObj.name,
+      }))}
     />
   ) : (
-    <DeploymentFilter projectOptions={projectOptions} />
+    <DeploymentFilter
+      projectOptions={projectOptions.map((projectObj) => ({
+        value: projectObj.nid,
+        label: projectObj.name,
+      }))}
+      speciesOptions={speciesOptions.map((speciesObj) => ({
+        value: speciesObj.species,
+        label: speciesObj.name,
+      }))}
+    />
   );
 }

--- a/next/app/projects/[projectId]/species/page.tsx
+++ b/next/app/projects/[projectId]/species/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 export default function Page({ params }: { params: { projectId: string } }) {
   const [data, setData] = useState<{
     species: string,
+    name: string,
     count: number,
   }[]>([]);
 
@@ -27,11 +28,13 @@ export default function Page({ params }: { params: { projectId: string } }) {
         <Table hoverable>
           <Table.Head>
             <Table.HeadCell>Species</Table.HeadCell>
+            <Table.HeadCell>Scientific Name</Table.HeadCell>
             <Table.HeadCell>Count</Table.HeadCell>
           </Table.Head>
           <Table.Body>
             {data?.map((row) => (
               <Table.Row key={row.species}>
+                <Table.Cell>{row.name}</Table.Cell>
                 <Table.Cell>{row.species}</Table.Cell>
                 <Table.Cell>{row.count}</Table.Cell>
               </Table.Row>

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -18,12 +18,14 @@ export default function DeploymentFilter({
   initialSpecies = [],
   initialProjects = [],
   projectOptions,
+  speciesOptions,
 }: {
   apiPath?: string | null,
   initialBounds?: RectBounds | null,
   initialSpecies?: string[],
   initialProjects?: number[],
   projectOptions: { value: number, label: string }[],
+  speciesOptions: { value: string, label: string }[],
 }) {
   const router = useRouter();
 
@@ -79,10 +81,10 @@ export default function DeploymentFilter({
           setFilter={setFilterSpecies}
           optionUrl={speciesUrl}
           optionValue="species"
-          optionLabel="species"
+          optionLabel="name"
           fieldLabel="Species"
-          defaultValues={initialSpecies.map((species) => (
-            { value: species, label: species }
+          defaultValues={speciesOptions.filter((speciesOption) => (
+            initialSpecies.includes(speciesOption.value)
           ))}
         />
         <DeploymentMultiselect

--- a/next/modules/map/components/DeploymentPopup.tsx
+++ b/next/modules/map/components/DeploymentPopup.tsx
@@ -12,6 +12,7 @@ import Deployment from '@/common/types/deployment';
 export default function DeploymentPopup({ marker }: { marker: Deployment }) {
   const [speciesData, setSpeciesData] = useState<{
     species: string,
+    name: string,
     count: number,
     nid: number,
   }[] | null>(null);
@@ -26,10 +27,15 @@ export default function DeploymentPopup({ marker }: { marker: Deployment }) {
     fetcher();
   };
 
-  const formatSpecies = (data: { species: string, count: number, nid: number }[]): string => {
+  const formatSpecies = (data: {
+    species: string,
+    name: string,
+    count: number,
+    nid: number
+  }[]): string => {
     const species: string[] = [];
     data.map((speciesObject) => (
-      species.push(speciesObject.species)
+      species.push(speciesObject.name)
     ));
     const result = species.join(', ');
     if (result.length > 25) {

--- a/next/modules/map/components/Filter.tsx
+++ b/next/modules/map/components/Filter.tsx
@@ -25,7 +25,7 @@ export default function Filter({ projectId }: { projectId: string }): React.Reac
         }).then((res) => res.json());
 
         const speciesOptions = species.map((speciesObj) => (
-          { value: speciesObj.species, label: speciesObj.species }
+          { value: speciesObj.species, label: speciesObj.name }
         ));
 
         resolve(filterOptions(inputValue, speciesOptions));


### PR DESCRIPTION
Use species common name in place of scientific name in page filters and species count summaries. This makes the filters more clear to users. This makes it much easier for users to search for familiar animals rather than having to search by their scientific name.