### PR TITLE
Single rectangle drawing

### DIFF
--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -68,7 +68,6 @@ export default function DeploymentFilter({
     <div className="container w-3/4 mx-auto flex flex-col justify-center items-center">
       <div className="w-full">
         <GeoFilterMap
-          filterBounds={rectBounds}
           setFilter={setRectBounds}
           apiPath={apiPath}
           mapping={deploymentMapping}

--- a/next/modules/map/components/EditFilterLayer.tsx
+++ b/next/modules/map/components/EditFilterLayer.tsx
@@ -38,6 +38,7 @@ export default function EditFilterLayer({ setFilter, layer, setLayer }) {
       }}
       onDeleted={() => {
         setFilter(null);
+        setLayer(null);
       }}
     />
   );

--- a/next/modules/map/components/EditFilterLayer.tsx
+++ b/next/modules/map/components/EditFilterLayer.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable no-underscore-dangle */
+
+'use client';
+
+import { useMap } from 'react-leaflet';
+import { EditControl } from 'react-leaflet-draw';
+
+import getLatLngs from '@/modules/map/utils/getLatLngs';
+
+export default function EditFilterLayer({ setFilter, layer, setLayer }) {
+  const map = useMap();
+
+  if (layer) {
+    if (!map.hasLayer(layer)) {
+      layer.addTo(map);
+    }
+  }
+
+  return (
+    <EditControl
+      position="topleft"
+      draw={{
+        circle: false,
+        polygon: false,
+        polyline: false,
+        marker: false,
+        circlemarker: false,
+      }}
+      onCreated={(e) => {
+        if (layer) {
+          map.removeLayer(layer);
+        }
+        setLayer(e.layer);
+        setFilter(getLatLngs(e.layer._bounds));
+      }}
+      onEdited={() => {
+        setFilter(getLatLngs(layer?._bounds));
+      }}
+      onDeleted={() => {
+        setFilter(null);
+      }}
+    />
+  );
+}

--- a/next/modules/map/components/EditFilterLayer.tsx
+++ b/next/modules/map/components/EditFilterLayer.tsx
@@ -10,9 +10,9 @@ import getLatLngs from '@/modules/map/utils/getLatLngs';
 export default function EditFilterLayer({ setFilter, layer, setLayer }) {
   const map = useMap();
 
-  if (layer) {
-    if (!map.hasLayer(layer)) {
-      layer.addTo(map);
+  if (layer.current) {
+    if (!map.hasLayer(layer.current)) {
+      layer.current.addTo(map);
     }
   }
 
@@ -27,14 +27,14 @@ export default function EditFilterLayer({ setFilter, layer, setLayer }) {
         circlemarker: false,
       }}
       onCreated={(e) => {
-        if (layer) {
-          map.removeLayer(layer);
+        if (layer.current) {
+          map.removeLayer(layer.current);
         }
         setLayer(e.layer);
         setFilter(getLatLngs(e.layer._bounds));
       }}
       onEdited={() => {
-        setFilter(getLatLngs(layer?._bounds));
+        setFilter(getLatLngs(layer.current?._bounds));
       }}
       onDeleted={() => {
         setFilter(null);

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -3,7 +3,8 @@
 'use client';
 
 import { Spinner } from 'flowbite-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { Layer, Map } from 'leaflet';
 import {
   FeatureGroup,
   MapContainer,
@@ -26,6 +27,9 @@ export default function GeoFilterMap({
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [markers, setMarkers] = useState<React.ReactNode | null>(null);
+
+  const map = useRef<Map>(null);
+  const rectLayer = useRef<Layer | null>(null);
 
   useEffect(() => {
     const fetchPoints = async () => {
@@ -55,7 +59,12 @@ export default function GeoFilterMap({
 
   return (
     <div>
-      <MapContainer center={[0, 0]} zoom={2.25} scrollWheelZoom>
+      <MapContainer
+        center={[0, 0]}
+        zoom={2.25}
+        scrollWheelZoom
+        ref={map}
+      >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -87,6 +96,10 @@ export default function GeoFilterMap({
               circlemarker: false,
             }}
             onCreated={(e) => {
+              if (rectLayer.current) {
+                map.current?.removeLayer(rectLayer.current);
+              }
+              rectLayer.current = e.layer;
               setFilter(getLatLngs(e.layer._bounds));
             }}
             onDeleted={() => {

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Spinner } from 'flowbite-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import {
   FeatureGroup,
@@ -23,7 +23,8 @@ export default function GeoFilterMap({
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [markers, setMarkers] = useState<React.ReactNode | null>(null);
-  const [rectLayer, setRectLayer] = useState<any>(null);
+
+  const rectLayer = useRef<any>(null);
 
   useEffect(() => {
     const fetchPoints = async () => {
@@ -59,7 +60,7 @@ export default function GeoFilterMap({
         maxLng,
         minLng,
       } = initialBounds;
-      setRectLayer(L.rectangle(L.latLngBounds([
+      rectLayer.current = L.rectangle(L.latLngBounds([
         parseFloat(minLat), parseFloat(minLng),
       ], [
         parseFloat(maxLat), parseFloat(maxLng),
@@ -68,7 +69,7 @@ export default function GeoFilterMap({
         opacity: 0.5,
         fillColor: '#3388ff',
         fillOpacity: 0.2,
-      }));
+      });
     }
   };
 
@@ -88,7 +89,13 @@ export default function GeoFilterMap({
           {markers}
         </MarkerClusterGroup>
         <FeatureGroup>
-          <EditFilterLayer setFilter={setFilter} layer={rectLayer} setLayer={setRectLayer} />
+          <EditFilterLayer
+            setFilter={setFilter}
+            layer={rectLayer}
+            setLayer={(layer) => {
+              rectLayer.current = layer;
+            }}
+          />
         </FeatureGroup>
       </MapContainer>
       {loading && (

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -1,20 +1,17 @@
-/* eslint-disable no-underscore-dangle */
-
 'use client';
 
 import { Spinner } from 'flowbite-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import L from 'leaflet';
 import {
   FeatureGroup,
   MapContainer,
   TileLayer,
-  useMap,
 } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-cluster';
-import { EditControl } from 'react-leaflet-draw';
 
-import getLatLngs from '@/modules/map/utils/getLatLngs';
+import EditFilterLayer from '@/modules/map/components/EditFilterLayer';
+
 import GeoFilterMapProps from '@/modules/map/types/GeoFilterMapProps';
 
 export default function GeoFilterMap({
@@ -26,8 +23,7 @@ export default function GeoFilterMap({
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [markers, setMarkers] = useState<React.ReactNode | null>(null);
-
-  const rectLayer = useRef<any>(null);
+  const [rectLayer, setRectLayer] = useState<any>(null);
 
   useEffect(() => {
     const fetchPoints = async () => {
@@ -63,7 +59,7 @@ export default function GeoFilterMap({
         maxLng,
         minLng,
       } = initialBounds;
-      rectLayer.current = L.rectangle(L.latLngBounds([
+      setRectLayer(L.rectangle(L.latLngBounds([
         parseFloat(minLat), parseFloat(minLng),
       ], [
         parseFloat(maxLat), parseFloat(maxLng),
@@ -72,44 +68,8 @@ export default function GeoFilterMap({
         opacity: 0.5,
         fillColor: '#3388ff',
         fillOpacity: 0.2,
-      });
+      }));
     }
-  };
-
-  const EditFilterLayer = () => {
-    const map = useMap();
-
-    if (rectLayer.current) {
-      if (!map.hasLayer(rectLayer.current)) {
-        rectLayer.current.addTo(map);
-      }
-    }
-
-    return (
-      <EditControl
-        position="topleft"
-        draw={{
-          circle: false,
-          polygon: false,
-          polyline: false,
-          marker: false,
-          circlemarker: false,
-        }}
-        onCreated={(e) => {
-          if (rectLayer.current) {
-            map?.removeLayer(rectLayer.current);
-          }
-          rectLayer.current = e.layer;
-          setFilter(getLatLngs(e.layer._bounds));
-        }}
-        onEdited={() => {
-          setFilter(getLatLngs(rectLayer.current?._bounds));
-        }}
-        onDeleted={() => {
-          setFilter(null);
-        }}
-      />
-    );
   };
 
   return (
@@ -128,7 +88,7 @@ export default function GeoFilterMap({
           {markers}
         </MarkerClusterGroup>
         <FeatureGroup>
-          <EditFilterLayer />
+          <EditFilterLayer setFilter={setFilter} layer={rectLayer} setLayer={setRectLayer} />
         </FeatureGroup>
       </MapContainer>
       {loading && (

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -4,11 +4,10 @@
 
 import { Spinner } from 'flowbite-react';
 import { useEffect, useRef, useState } from 'react';
-import { Layer, Map } from 'leaflet';
+import L, { Layer, Map } from 'leaflet';
 import {
   FeatureGroup,
   MapContainer,
-  Rectangle,
   TileLayer,
 } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-cluster';
@@ -18,7 +17,6 @@ import getLatLngs from '@/modules/map/utils/getLatLngs';
 import GeoFilterMapProps from '@/modules/map/types/GeoFilterMapProps';
 
 export default function GeoFilterMap({
-  filterBounds,
   setFilter,
   apiPath,
   mapping,
@@ -57,6 +55,28 @@ export default function GeoFilterMap({
     fetchPoints();
   }, [apiPath]);
 
+  useEffect(() => {
+    if (initialBounds && Object.keys(initialBounds).length > 0 && map.current) {
+      const {
+        maxLat,
+        minLat,
+        maxLng,
+        minLng,
+      } = initialBounds;
+      rectLayer.current = L.rectangle(L.latLngBounds([
+        parseFloat(minLat), parseFloat(minLng),
+      ], [
+        parseFloat(maxLat), parseFloat(maxLng),
+      ]), {
+        color: '#3388ff',
+        opacity: 0.5,
+        fillColor: '#3388ff',
+        fillOpacity: 0.2,
+      });
+      rectLayer.current.addTo(map.current);
+    }
+  }, [map.current]);
+
   return (
     <div>
       <MapContainer
@@ -72,19 +92,6 @@ export default function GeoFilterMap({
         <MarkerClusterGroup>
           {markers}
         </MarkerClusterGroup>
-        {initialBounds && Object.keys(initialBounds).length > 0
-          && filterBounds === initialBounds && (
-            <Rectangle
-              bounds={[
-                [parseFloat(initialBounds.maxLat), parseFloat(initialBounds.minLng)],
-                [parseFloat(initialBounds.minLat), parseFloat(initialBounds.maxLng)],
-              ]}
-              color="#3388ff"
-              opacity={0.5}
-              fillColor="#3388ff"
-              fillOpacity={0.2}
-            />
-        )}
         <FeatureGroup>
           <EditControl
             position="topleft"

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -4,7 +4,7 @@
 
 import { Spinner } from 'flowbite-react';
 import { useEffect, useRef, useState } from 'react';
-import L, { Layer, Map } from 'leaflet';
+import L, { Map } from 'leaflet';
 import {
   FeatureGroup,
   MapContainer,
@@ -27,7 +27,7 @@ export default function GeoFilterMap({
   const [markers, setMarkers] = useState<React.ReactNode | null>(null);
 
   const map = useRef<Map>(null);
-  const rectLayer = useRef<Layer | null>(null);
+  const rectLayer = useRef<any>(null);
 
   useEffect(() => {
     const fetchPoints = async () => {
@@ -108,6 +108,9 @@ export default function GeoFilterMap({
               }
               rectLayer.current = e.layer;
               setFilter(getLatLngs(e.layer._bounds));
+            }}
+            onEdited={() => {
+              setFilter(getLatLngs(rectLayer.current?._bounds));
             }}
             onDeleted={() => {
               setFilter(null);

--- a/next/modules/map/types/GeoFilterMapProps.ts
+++ b/next/modules/map/types/GeoFilterMapProps.ts
@@ -1,7 +1,6 @@
 import RectBounds from '@/modules/map/types/RectBounds';
 
 export default interface GeoFilterMapProps {
-  filterBounds: RectBounds | null,
   setFilter: React.Dispatch<React.SetStateAction<RectBounds | null>>,
   apiPath: string | null,
   mapping: (mkr: any) => React.ReactNode,


### PR DESCRIPTION
Allow only one drawn rectangle for the geographical filter. Enable the edit feature to allow a user to move and resize the rectangle.