### PR TITLE
Loading deployments

### DIFF
--- a/next/app/layout.tsx
+++ b/next/app/layout.tsx
@@ -3,6 +3,9 @@ import './leaflet.css';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';
 
+import 'leaflet.markercluster/dist/MarkerCluster.css';
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -6,10 +6,11 @@ import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 
+import DeploymentMultiselect from '@/modules/map/components/DeploymentMultiselect';
+
 import RectBounds from '@/modules/map/types/RectBounds';
 
 const GeoFilterMap = dynamic(() => import('@/modules/map/components/GeoFilterMap'), { ssr: false });
-const DeploymentMultiselect = dynamic(() => import('@/modules/map/components/DeploymentMultiselect'), { ssr: false });
 
 export default function DeploymentFilter({
   apiPath = null,

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -31,6 +31,7 @@ export default function DeploymentFilter({
   const [rectBounds, setRectBounds] = useState<RectBounds | null>(initialBounds);
   const [filterSpecies, setFilterSpecies] = useState<string[]>(initialSpecies);
   const [filterProjects, setFilterProjects] = useState<number[]>(initialProjects);
+  const [mapReady, setMapReady] = useState<boolean>(false);
   const [speciesUrl, setSpeciesUrl] = useState<string>(`/api/species?${new URLSearchParams({
     projects: JSON.stringify(initialProjects),
     ...initialBounds,
@@ -71,48 +72,53 @@ export default function DeploymentFilter({
           apiPath={apiPath}
           initialBounds={initialBounds}
           setCsvData={setCsvData}
+          setReady={setMapReady}
         />
       </div>
-      <div className="w-full flex flex-row justify-left">
-        <DeploymentMultiselect
-          setFilter={setFilterSpecies}
-          optionUrl={speciesUrl}
-          optionValue="species"
-          optionLabel="name"
-          fieldLabel="Species"
-          defaultValues={speciesOptions.filter((speciesOption) => (
-            initialSpecies.includes(speciesOption.value)
-          ))}
-        />
-        <DeploymentMultiselect
-          setFilter={setFilterProjects}
-          optionUrl={projectsUrl}
-          optionValue="nid"
-          optionLabel="name"
-          fieldLabel="Projects"
-          defaultValues={projectOptions.filter((projectOption) => (
-            initialProjects.includes(projectOption.value)
-          ))}
-        />
-        <Button type="button" onClick={handleSubmit}>Search</Button>
-      </div>
-      {(csvData || !apiPath) ? (
+      {mapReady && (
         <>
-          {csvData && csvData.length > 0 && (
-            <CSVLink
-              data={csvData}
-              filename={`deployment_metadata_${new Date().toISOString().replaceAll(/[^0-9]/g, '')}`}
-            >
-              <Button>
-                Download Deployment Data
-              </Button>
-            </CSVLink>
+          <div className="w-full flex flex-row justify-left">
+            <DeploymentMultiselect
+              setFilter={setFilterSpecies}
+              optionUrl={speciesUrl}
+              optionValue="species"
+              optionLabel="name"
+              fieldLabel="Species"
+              defaultValues={speciesOptions.filter((speciesOption) => (
+                initialSpecies.includes(speciesOption.value)
+              ))}
+            />
+            <DeploymentMultiselect
+              setFilter={setFilterProjects}
+              optionUrl={projectsUrl}
+              optionValue="nid"
+              optionLabel="name"
+              fieldLabel="Projects"
+              defaultValues={projectOptions.filter((projectOption) => (
+                initialProjects.includes(projectOption.value)
+              ))}
+            />
+            <Button type="button" onClick={handleSubmit}>Search</Button>
+          </div>
+          {(csvData || !apiPath) ? (
+            <>
+              {csvData && csvData.length > 0 && (
+                <CSVLink
+                  data={csvData}
+                  filename={`deployment_metadata_${new Date().toISOString().replaceAll(/[^0-9]/g, '')}`}
+                >
+                  <Button>
+                    Download Deployment Data
+                  </Button>
+                </CSVLink>
+              )}
+            </>
+          ) : (
+            <Button isProcessing>
+              Download Deployment Data
+            </Button>
           )}
         </>
-      ) : (
-        <Button isProcessing>
-          Download Deployment Data
-        </Button>
       )}
     </div>
   );

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -7,7 +7,6 @@ import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 
 import RectBounds from '@/modules/map/types/RectBounds';
-import deploymentMapping from '@/modules/map/utils/deploymentMapping';
 
 const GeoFilterMap = dynamic(() => import('@/modules/map/components/GeoFilterMap'), { ssr: false });
 const DeploymentMultiselect = dynamic(() => import('@/modules/map/components/DeploymentMultiselect'), { ssr: false });
@@ -70,7 +69,6 @@ export default function DeploymentFilter({
         <GeoFilterMap
           setFilter={setRectBounds}
           apiPath={apiPath}
-          mapping={deploymentMapping}
           initialBounds={initialBounds}
           setCsvData={setCsvData}
         />

--- a/next/modules/map/components/DeploymentMultiselect.tsx
+++ b/next/modules/map/components/DeploymentMultiselect.tsx
@@ -1,9 +1,20 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
-import Select from 'react-select';
+import PlaceholderSelect from 'react-select';
 
 import selectStyles from '@/modules/map/utils/selectStyles';
+
+const Select = dynamic(() => import('react-select'), {
+  ssr: false,
+  loading: () => (
+    <PlaceholderSelect
+      isMulti
+      isLoading
+    />
+  ),
+});
 
 export default function DeploymentMultiselect(
   {

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -22,7 +22,7 @@ export default function GeoFilterMap({
   setCsvData,
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
-  const [markers, setMarkers] = useState<React.ReactNode | null>(null);
+  const [markers, setMarkers] = useState<React.ReactNode[] | null>(null);
 
   const rectLayer = useRef<any>(null);
 
@@ -35,7 +35,7 @@ export default function GeoFilterMap({
           method: 'GET',
         }).then((res) => res.json());
 
-        const markerComponents: React.ReactNode = points.map(mapping);
+        const markerComponents: React.ReactNode[] = points.map(mapping);
         setMarkers(markerComponents);
         setLoading(false);
 

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -37,7 +37,6 @@ export default function GeoFilterMap({
         }).then((res) => res.json());
 
         setMarkers(deployments);
-        setLoading(false);
 
         if (setCsvData) {
           const csvRows = await fetch('/api/deployments/csv', {
@@ -53,6 +52,12 @@ export default function GeoFilterMap({
 
     fetchPoints();
   }, [apiPath]);
+
+  useEffect(() => {
+    if (markers) {
+      setLoading(false);
+    }
+  }, [markers]);
 
   const handleMapReady = () => {
     if (initialBounds && Object.keys(initialBounds).length > 0) {

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -8,11 +8,9 @@ import {
   MapContainer,
   TileLayer,
 } from 'react-leaflet';
-import MarkerClusterGroup from 'react-leaflet-cluster';
 
+import MarkerCluster from '@/modules/map/components/MarkerCluster';
 import EditFilterLayer from '@/modules/map/components/EditFilterLayer';
-
-import deploymentMapping from '@/modules/map/utils/deploymentMapping';
 
 import GeoFilterMapProps from '@/modules/map/types/GeoFilterMapProps';
 import Deployment from '@/common/types/deployment';
@@ -26,6 +24,7 @@ export default function GeoFilterMap({
   const [loading, setLoading] = useState<boolean>(false);
   const [markers, setMarkers] = useState<Deployment[] | null>(null);
 
+  const markersLayer = useRef<any>(null);
   const rectLayer = useRef<any>(null);
 
   useEffect(() => {
@@ -33,18 +32,17 @@ export default function GeoFilterMap({
       if (apiPath && apiPath.length > 0) {
         setCsvData(null);
         setLoading(true);
-        const points: Deployment[] = await fetch(apiPath, {
+        const deployments: Deployment[] = await fetch(apiPath, {
           method: 'GET',
         }).then((res) => res.json());
 
-        const markerComponents: React.ReactNode[] = points.map(deploymentMapping);
-        setMarkers(markerComponents);
+        setMarkers(deployments);
         setLoading(false);
 
         if (setCsvData) {
           const csvRows = await fetch('/api/deployments/csv', {
             method: 'POST',
-            body: JSON.stringify(points.map((point) => point.nid)),
+            body: JSON.stringify(deployments.map((point) => point.nid)),
           }).then((res) => res.json());
           setCsvData(csvRows);
         }
@@ -87,9 +85,11 @@ export default function GeoFilterMap({
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <MarkerClusterGroup>
-          {markers}
-        </MarkerClusterGroup>
+        <MarkerCluster
+          markers={markers}
+          layer={markersLayer}
+          setLayer={(layer) => { markersLayer.current = layer; }}
+        />
         <FeatureGroup>
           <EditFilterLayer
             setFilter={setFilter}

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -12,17 +12,19 @@ import MarkerClusterGroup from 'react-leaflet-cluster';
 
 import EditFilterLayer from '@/modules/map/components/EditFilterLayer';
 
+import deploymentMapping from '@/modules/map/utils/deploymentMapping';
+
 import GeoFilterMapProps from '@/modules/map/types/GeoFilterMapProps';
+import Deployment from '@/common/types/deployment';
 
 export default function GeoFilterMap({
   setFilter,
   apiPath,
-  mapping,
   initialBounds,
   setCsvData,
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
-  const [markers, setMarkers] = useState<React.ReactNode[] | null>(null);
+  const [markers, setMarkers] = useState<Deployment[] | null>(null);
 
   const rectLayer = useRef<any>(null);
 
@@ -31,11 +33,11 @@ export default function GeoFilterMap({
       if (apiPath && apiPath.length > 0) {
         setCsvData(null);
         setLoading(true);
-        const points: any[] = await fetch(apiPath, {
+        const points: Deployment[] = await fetch(apiPath, {
           method: 'GET',
         }).then((res) => res.json());
 
-        const markerComponents: React.ReactNode[] = points.map(mapping);
+        const markerComponents: React.ReactNode[] = points.map(deploymentMapping);
         setMarkers(markerComponents);
         setLoading(false);
 

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -46,6 +46,8 @@ export default function GeoFilterMap({
           }).then((res) => res.json());
           setCsvData(csvRows);
         }
+      } else {
+        setMarkers([]);
       }
     };
 

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -81,7 +81,7 @@ export default function GeoFilterMap({
   };
 
   return (
-    <div>
+    <div className="relative">
       <MapContainer
         center={[0, 0]}
         zoom={2.25}

--- a/next/modules/map/components/GeoFilterMap.tsx
+++ b/next/modules/map/components/GeoFilterMap.tsx
@@ -20,6 +20,7 @@ export default function GeoFilterMap({
   apiPath,
   initialBounds,
   setCsvData,
+  setReady,
 }: GeoFilterMapProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [markers, setMarkers] = useState<Deployment[] | null>(null);
@@ -78,6 +79,7 @@ export default function GeoFilterMap({
         fillOpacity: 0.2,
       });
     }
+    setReady(true);
   };
 
   return (

--- a/next/modules/map/components/MarkerCluster.tsx
+++ b/next/modules/map/components/MarkerCluster.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import L from 'leaflet';
+import { useMap } from 'react-leaflet';
+import { useEffect } from 'react';
+
+import 'leaflet.markercluster/dist/leaflet.markercluster-src';
+
+import Deployment from '@/common/types/deployment';
+
+export default function MarkerCluster({
+  markers,
+  layer,
+  setLayer,
+}: {
+  markers: Deployment[] | null,
+  layer: any,
+  setLayer: Function,
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (markers && markers.length > 0) {
+      const markerGroup = L.markerClusterGroup();
+
+      markers?.forEach((marker) => {
+        const newMarker = L.marker(L.latLng(marker.latitude, marker.longitude), {
+          icon: L.icon({
+            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+            shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12.5, 41],
+            popupAnchor: [0, -41],
+          }),
+        });
+        newMarker.addTo(markerGroup);
+      });
+
+      if (layer.current) {
+        map.removeLayer(layer.current);
+      }
+      markerGroup.addTo(map);
+      setLayer(markerGroup);
+    }
+  }, [markers]);
+
+  return null;
+}

--- a/next/modules/map/components/MarkerCluster.tsx
+++ b/next/modules/map/components/MarkerCluster.tsx
@@ -20,7 +20,7 @@ export default function MarkerCluster({
   const map = useMap();
 
   useEffect(() => {
-    if (markers && markers.length > 0) {
+    if (markers) {
       const markerGroup = L.markerClusterGroup();
 
       markers?.forEach((marker) => {

--- a/next/modules/map/components/MarkerCluster.tsx
+++ b/next/modules/map/components/MarkerCluster.tsx
@@ -33,6 +33,9 @@ export default function MarkerCluster({
             popupAnchor: [0, -41],
           }),
         });
+        const newPopup = L.popup();
+        newPopup.setContent(marker.label);
+        newMarker.bindPopup(newPopup);
         newMarker.addTo(markerGroup);
       });
 

--- a/next/modules/map/types/GeoFilterMapProps.ts
+++ b/next/modules/map/types/GeoFilterMapProps.ts
@@ -3,7 +3,6 @@ import RectBounds from '@/modules/map/types/RectBounds';
 export default interface GeoFilterMapProps {
   setFilter: React.Dispatch<React.SetStateAction<RectBounds | null>>,
   apiPath: string | null,
-  mapping: (mkr: any) => React.ReactNode,
   initialBounds?: RectBounds | null,
   setCsvData: React.Dispatch<React.SetStateAction<any[] | null>>,
 }

--- a/next/modules/map/types/GeoFilterMapProps.ts
+++ b/next/modules/map/types/GeoFilterMapProps.ts
@@ -5,4 +5,5 @@ export default interface GeoFilterMapProps {
   apiPath: string | null,
   initialBounds?: RectBounds | null,
   setCsvData: React.Dispatch<React.SetStateAction<any[] | null>>,
+  setReady: React.Dispatch<React.SetStateAction<boolean>>,
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "#express/*": "./express/*.js"
   },
   "dependencies": {
+    "@types/leaflet.markercluster": "^1.5.4",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -23,6 +24,7 @@
     "flowbite-react": "^0.5.0",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
+    "leaflet.markercluster": "^1.5.3",
     "mariadb": "^3.2.0",
     "next": "^13.4.9",
     "pg": "^8.11.1",


### PR DESCRIPTION
Fix the loading animation for deployment filtering. Add leaflet.markercluster to the project and manually implement cluster layer handling to optimize marker render times. This allows many more markers to be rendered on the page in a short amount of time. Fix animation overlay style so that the loading spinner overlays on the map only rather than the whole page. Use placeholders and conditional rendering to make initial page load more graceful.