### PR TITLE
Filter overflow issue

### DIFF
--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -82,26 +82,30 @@ export default function DeploymentFilter({
       {mapReady && (
         <div className="w-full flex flex-row my-2">
           <div className="flex flex-row flex-grow">
-            <DeploymentMultiselect
-              setFilter={setFilterSpecies}
-              optionUrl={speciesUrl}
-              optionValue="species"
-              optionLabel="name"
-              fieldLabel="Species"
-              defaultValues={speciesOptions.filter((speciesOption) => (
-                initialSpecies.includes(speciesOption.value)
-              ))}
-            />
-            <DeploymentMultiselect
-              setFilter={setFilterProjects}
-              optionUrl={projectsUrl}
-              optionValue="nid"
-              optionLabel="name"
-              fieldLabel="Projects"
-              defaultValues={projectOptions.filter((projectOption) => (
-                initialProjects.includes(projectOption.value)
-              ))}
-            />
+            <div className="w-1/2">
+              <DeploymentMultiselect
+                setFilter={setFilterSpecies}
+                optionUrl={speciesUrl}
+                optionValue="species"
+                optionLabel="name"
+                fieldLabel="Species"
+                defaultValues={speciesOptions.filter((speciesOption) => (
+                  initialSpecies.includes(speciesOption.value)
+                ))}
+              />
+            </div>
+            <div className="w-1/2">
+              <DeploymentMultiselect
+                setFilter={setFilterProjects}
+                optionUrl={projectsUrl}
+                optionValue="nid"
+                optionLabel="name"
+                fieldLabel="Projects"
+                defaultValues={projectOptions.filter((projectOption) => (
+                  initialProjects.includes(projectOption.value)
+                ))}
+              />
+            </div>
           </div>
           <div className="flex flex-row flex-shrink-0 justify-items-center">
             <Button type="button" onClick={handleSubmit} className="mx-2">Search</Button>

--- a/next/modules/map/components/DeploymentMultiselect.tsx
+++ b/next/modules/map/components/DeploymentMultiselect.tsx
@@ -61,7 +61,7 @@ export default function DeploymentMultiselect(
   };
 
   return (
-    <div className="flex flex-row items-center w-1/2 mx-4">
+    <div className="flex flex-row items-center mx-4">
       <div className="flex-grow-0 mr-2">
         {fieldLabel}
       </div>

--- a/next/modules/map/utils/selectStyles.ts
+++ b/next/modules/map/utils/selectStyles.ts
@@ -5,15 +5,20 @@ const selectStyles = {
   }),
   control: (base) => ({
     ...base,
-    maxHeight: '35px',
+    maxHeight: '36px',
   }),
   valueContainer: (base) => ({
     ...base,
-    maxHeight: '35px',
+    maxHeight: '36px',
+    overflow: 'auto',
+  }),
+  multiValueLabel: (base) => ({
+    ...base,
+    whiteSpace: 'normal',
   }),
   indicatorsContainer: (base) => ({
     ...base,
-    maxHeight: '35px',
+    maxHeight: '36px',
   }),
 };
 


### PR DESCRIPTION
Fix issues with selecting a long-named value in the react-multiselect components in the deployment filter. This prevents the multiselect elements from rendering underneath buttons.