### PR TITLE
Responsive layout

### DIFF
--- a/next/modules/map/components/DeploymentDrawer.tsx
+++ b/next/modules/map/components/DeploymentDrawer.tsx
@@ -33,7 +33,7 @@ export default function DeploymentDrawer({ isOpen, deployment }) {
   }, [deployment]);
 
   return (
-    <div className={`h-full transition-all duration-500 overflow-x-hidden ${isOpen ? 'w-1/5 mr-2' : 'w-0 pointer-events-none'}`}>
+    <div className={`h-full transition-all duration-500 overflow-x-hidden ${isOpen ? 'w-3/4 mr-2 sm:w-1/2 md:w-1/3 xl:w-1/5' : 'w-0 pointer-events-none'}`}>
       {deployment ? (
         <>
           {projectData ? (

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -80,8 +80,8 @@ export default function DeploymentFilter({
   return (
     <div className="h-screen flex flex-col">
       {mapReady && (
-        <div className="w-full flex flex-col my-2">
-          <div className="flex flex-col sm:flex-row">
+        <div className="w-full flex flex-col my-2 lg:flex-row">
+          <div className="grow flex flex-col sm:flex-row">
             <div className="p-2 sm:w-1/2">
               <DeploymentMultiselect
                 setFilter={setFilterSpecies}

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -81,8 +81,8 @@ export default function DeploymentFilter({
     <div className="h-screen flex flex-col">
       {mapReady && (
         <div className="w-full flex flex-col my-2">
-          <div className="flex flex-col">
-            <div className="p-2">
+          <div className="flex flex-col sm:flex-row">
+            <div className="p-2 sm:w-1/2">
               <DeploymentMultiselect
                 setFilter={setFilterSpecies}
                 optionUrl={speciesUrl}
@@ -94,7 +94,7 @@ export default function DeploymentFilter({
                 ))}
               />
             </div>
-            <div className="p-2">
+            <div className="p-2 sm:w-1/2">
               <DeploymentMultiselect
                 setFilter={setFilterProjects}
                 optionUrl={projectsUrl}

--- a/next/modules/map/components/DeploymentFilter.tsx
+++ b/next/modules/map/components/DeploymentFilter.tsx
@@ -80,9 +80,9 @@ export default function DeploymentFilter({
   return (
     <div className="h-screen flex flex-col">
       {mapReady && (
-        <div className="w-full flex flex-row my-2">
-          <div className="flex flex-row flex-grow">
-            <div className="w-1/2">
+        <div className="w-full flex flex-col my-2">
+          <div className="flex flex-col">
+            <div className="p-2">
               <DeploymentMultiselect
                 setFilter={setFilterSpecies}
                 optionUrl={speciesUrl}
@@ -94,7 +94,7 @@ export default function DeploymentFilter({
                 ))}
               />
             </div>
-            <div className="w-1/2">
+            <div className="p-2">
               <DeploymentMultiselect
                 setFilter={setFilterProjects}
                 optionUrl={projectsUrl}
@@ -107,7 +107,7 @@ export default function DeploymentFilter({
               />
             </div>
           </div>
-          <div className="flex flex-row flex-shrink-0 justify-items-center">
+          <div className="flex flex-row flex-shrink-0 justify-end p-2">
             <Button type="button" onClick={handleSubmit} className="mx-2">Search</Button>
             {(csvData || !apiPath) ? (
               <>

--- a/next/modules/map/components/MarkerCluster.tsx
+++ b/next/modules/map/components/MarkerCluster.tsx
@@ -60,7 +60,8 @@ export default function MarkerCluster({
         const bounds = new L.LatLngBounds(markerLatLngs);
         if (drawerOpen) {
           const boundWidth = bounds.getEast() - bounds.getWest();
-          bounds.extend([bounds.getNorth(), bounds.getEast() + boundWidth * 0.3]);
+          bounds.extend([bounds.getNorth(), bounds.getEast() + boundWidth]);
+          bounds.extend([bounds.getSouth(), bounds.getWest() - boundWidth * 0.25]);
         }
         map.fitBounds(bounds);
       }


### PR DESCRIPTION
Use a mobile-first responsive design on the deployment filter page. Handle different breakpoints, arranging the multiselect components, button components, and adjusting drawer width as necessary to fit content on the page in an acceptable way.